### PR TITLE
Add proof state subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 vendor
 .keys
 tmcli

--- a/commands/proofs/get.go
+++ b/commands/proofs/get.go
@@ -1,88 +1,14 @@
 package proofs
 
 import (
-	"fmt"
-
-	"github.com/pkg/errors"
-
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	data "github.com/tendermint/go-wire/data"
 	lc "github.com/tendermint/light-client"
 	"github.com/tendermint/light-client/commands"
 	"github.com/tendermint/tendermint/rpc/client"
 )
 
-// MakeGetCmd creates the get or list command for a proof
-func (p ProofCommander) MakeGetCmd(includeKey bool, use, desc string) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:          use,
-		Short:        desc,
-		RunE:         p.makeGetCmd(includeKey),
-		SilenceUsage: true,
-	}
-	cmd.Flags().Int(heightFlag, 0, "Height to query (skip to use latest block)")
-	cmd.Flags().String(appFlag, "raw", "App to use to interpret data")
-	if includeKey {
-		cmd.Flags().String(keyFlag, "", "Key to query on")
-	}
-	return cmd
-}
-
-func (p ProofCommander) makeGetCmd(includeKey bool) func(cmd *cobra.Command, args []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		app := viper.GetString(appFlag)
-
-		var rawkey string
-		if includeKey {
-			rawkey = viper.GetString(keyFlag)
-			if rawkey == "" {
-				return errors.New("missing required flag: --" + keyFlag)
-			}
-		}
-
-		height := viper.GetInt(heightFlag)
-
-		pres, err := p.Lookup(app)
-		if err != nil {
-			return err
-		}
-
-		// prepare the query in an app-dependent manner
-		key, err := pres.MakeKey(rawkey)
-		if err != nil {
-			return err
-		}
-
-		//get the proof
-		proof, err := p.GetProof(key, height)
-		if err != nil {
-			return err
-		}
-
-		info, err := pres.ParseData(proof.Data())
-		if err != nil {
-			return err
-		}
-
-		data, err := data.ToJSON(info)
-		if err != nil {
-			return err
-		}
-
-		// TODO: store the proof or do something more interesting than just printing
-		fmt.Printf("Height: %d\n", proof.BlockHeight())
-		fmt.Println(string(data))
-		return nil
-	}
-}
-
 // GetProof performs the get command directly from the proof (not from the CLI)
-func (p ProofCommander) GetProof(key []byte, height int) (proof lc.Proof, err error) {
-
-	// instantiate the prover instance and get a proof from the server
-	p.Init()
-	proof, err = p.Get(key, uint64(height))
+func GetProof(node client.Client, prover lc.Prover, key []byte, height int) (proof lc.Proof, err error) {
+	proof, err = prover.Get(key, uint64(height))
 	if err != nil {
 		return
 	}
@@ -98,8 +24,8 @@ func (p ProofCommander) GetProof(key []byte, height int) (proof lc.Proof, err er
 	// FIXME: cannot use cert.GetByHeight for now, as it also requires
 	// Validators and will fail on querying tendermint for non-current height.
 	// When this is supported, we should use it instead...
-	client.WaitForHeight(p.node, ph, nil)
-	commit, err := p.node.Commit(ph)
+	client.WaitForHeight(node, ph, nil)
+	commit, err := node.Commit(ph)
 	if err != nil {
 		return
 	}

--- a/commands/proofs/get.go
+++ b/commands/proofs/get.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	data "github.com/tendermint/go-data"
+	data "github.com/tendermint/go-wire/data"
 	lc "github.com/tendermint/light-client"
 	"github.com/tendermint/light-client/commands"
 	"github.com/tendermint/tendermint/rpc/client"

--- a/commands/proofs/get.go
+++ b/commands/proofs/get.go
@@ -1,9 +1,10 @@
 package proofs
 
 import (
+	"github.com/tendermint/tendermint/rpc/client"
+
 	lc "github.com/tendermint/light-client"
 	"github.com/tendermint/light-client/commands"
-	"github.com/tendermint/tendermint/rpc/client"
 )
 
 // GetProof performs the get command directly from the proof (not from the CLI)

--- a/commands/proofs/root.go
+++ b/commands/proofs/root.go
@@ -36,12 +36,6 @@ func (p *ProofCommander) Init() {
 	p.Prover = p.ProverFunc(p.node)
 }
 
-func (p ProofCommander) Register(parent *cobra.Command, cmdReg func(ProofCommander) *cobra.Command) {
-	// we add each subcommand here, so we can register the
-	// ProofCommander in one swoop
-	parent.AddCommand(cmdReg(p))
-}
-
 func (p ProofCommander) RegisterGet(parent *cobra.Command) {
 	// we add each subcommand here, so we can register the
 	// ProofCommander in one swoop

--- a/commands/proofs/root.go
+++ b/commands/proofs/root.go
@@ -39,7 +39,18 @@ func (p *ProofCommander) Init() {
 func (p ProofCommander) RegisterGet(parent *cobra.Command) {
 	// we add each subcommand here, so we can register the
 	// ProofCommander in one swoop
-	parent.AddCommand(p.GetCmd())
+	parent.AddCommand(p.MakeGetCmd(
+		true,
+		"get",
+		"Get a proof from the tendermint node",
+	))
+}
+func (p ProofCommander) RegisterList(parent *cobra.Command) {
+	parent.AddCommand(p.MakeGetCmd(
+		false,
+		"list",
+		"Get a list proof from the tendermint node",
+	))
 }
 
 const (

--- a/commands/proofs/root.go
+++ b/commands/proofs/root.go
@@ -36,20 +36,20 @@ func init() {
 }
 
 // ParseHexKey parses the key flag as hex and converts to bytes or returns error
-// if prefix is non-nil, it prepends this constant to the given key (eg. "base/a/")
-func ParseHexKey(args []string, prefix []byte) ([]byte, error) {
+// argname is used to customize the error message
+func ParseHexKey(args []string, argname string) ([]byte, error) {
 	if len(args) == 0 {
-		return nil, errors.New("Missing required key argument")
+		return nil, errors.Errorf("Missing required argument [%s]", argname)
 	}
 	if len(args) > 1 {
-		return nil, errors.Errorf("Only accepts one key argument")
+		return nil, errors.Errorf("Only accepts one argument [%s]", argname)
 	}
 	rawkey := args[0]
 	if rawkey == "" {
-		return nil, errors.New("Cannot query on empty key")
+		return nil, errors.Errorf("[%s] argument must be non-empty ", argname)
 	}
 	// with tx, we always just parse key as hex and use to lookup
-	return proofs.KeyMaker{prefix}.MakeKey(rawkey)
+	return proofs.ParseHexKey(rawkey)
 }
 
 func GetHeight() int {

--- a/commands/proofs/root.go
+++ b/commands/proofs/root.go
@@ -36,7 +36,13 @@ func (p *ProofCommander) Init() {
 	p.Prover = p.ProverFunc(p.node)
 }
 
-func (p ProofCommander) Register(parent *cobra.Command) {
+func (p ProofCommander) Register(parent *cobra.Command, cmdReg func(ProofCommander) *cobra.Command) {
+	// we add each subcommand here, so we can register the
+	// ProofCommander in one swoop
+	parent.AddCommand(cmdReg(p))
+}
+
+func (p ProofCommander) RegisterGet(parent *cobra.Command) {
 	// we add each subcommand here, so we can register the
 	// ProofCommander in one swoop
 	parent.AddCommand(p.GetCmd())

--- a/commands/proofs/root.go
+++ b/commands/proofs/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/tendermint/go-wire/data"
 
@@ -13,7 +14,6 @@ import (
 
 const (
 	heightFlag = "height"
-	keyFlag    = "key"
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -32,7 +32,7 @@ func init() {
 	RootCmd.Flags().Int(heightFlag, 0, "Height to query (skip to use latest block)")
 
 	RootCmd.AddCommand(txCmd)
-	RootCmd.AddCommand(stateCmd)
+	RootCmd.AddCommand(keyCmd)
 }
 
 // ParseHexKey parses the key flag as hex and converts to bytes or returns error
@@ -50,6 +50,10 @@ func ParseHexKey(args []string, prefix []byte) ([]byte, error) {
 	}
 	// with tx, we always just parse key as hex and use to lookup
 	return proofs.KeyMaker{prefix}.MakeKey(rawkey)
+}
+
+func GetHeight() int {
+	return viper.GetInt(heightFlag)
 }
 
 // OutputProof prints the proof to stdout

--- a/commands/proofs/root.go
+++ b/commands/proofs/root.go
@@ -1,17 +1,24 @@
 package proofs
 
 import (
+	"fmt"
+
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	lc "github.com/tendermint/light-client"
-	"github.com/tendermint/light-client/commands"
+
+	"github.com/tendermint/go-wire/data"
+
 	"github.com/tendermint/light-client/proofs"
-	"github.com/tendermint/tendermint/rpc/client"
+)
+
+const (
+	heightFlag = "height"
+	keyFlag    = "key"
 )
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
-	Use:   "proof",
+	Use:   "query",
 	Short: "Get and store merkle proofs for blockchain data",
 	Long: `Proofs allows you to validate data and merkle proofs.
 
@@ -21,40 +28,42 @@ data to other peers as needed.
 `,
 }
 
-type ProofCommander struct {
-	node client.Client
-	lc.Prover
-	ProverFunc func(client.Client) lc.Prover
-	proofs.Presenters
+func init() {
+	RootCmd.Flags().Int(heightFlag, 0, "Height to query (skip to use latest block)")
+
+	RootCmd.AddCommand(txCmd)
+	RootCmd.AddCommand(stateCmd)
 }
 
-// Init uses configuration info to create a network connection
-// as well as initializing the prover
-func (p *ProofCommander) Init() {
-	endpoint := viper.GetString(commands.NodeFlag)
-	p.node = client.NewHTTP(endpoint, "/websockets")
-	p.Prover = p.ProverFunc(p.node)
+// ParseHexKey parses the key flag as hex and converts to bytes or returns error
+// if prefix is non-nil, it prepends this constant to the given key (eg. "base/a/")
+func ParseHexKey(args []string, prefix []byte) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, errors.New("Missing required key argument")
+	}
+	if len(args) > 1 {
+		return nil, errors.Errorf("Only accepts one key argument")
+	}
+	rawkey := args[0]
+	if rawkey == "" {
+		return nil, errors.New("Cannot query on empty key")
+	}
+	// with tx, we always just parse key as hex and use to lookup
+	return proofs.KeyMaker{prefix}.MakeKey(rawkey)
 }
 
-func (p ProofCommander) RegisterGet(parent *cobra.Command) {
-	// we add each subcommand here, so we can register the
-	// ProofCommander in one swoop
-	parent.AddCommand(p.MakeGetCmd(
-		true,
-		"get",
-		"Get a proof from the tendermint node",
-	))
-}
-func (p ProofCommander) RegisterList(parent *cobra.Command) {
-	parent.AddCommand(p.MakeGetCmd(
-		false,
-		"list",
-		"Get a list proof from the tendermint node",
-	))
-}
+// OutputProof prints the proof to stdout
+// reuse this for printing proofs and we should enhance this for text/json,
+// better presentation of height
+func OutputProof(info interface{}, height uint64) error {
+	res, err := data.ToJSON(info)
+	if err != nil {
+		return err
+	}
 
-const (
-	heightFlag = "height"
-	appFlag    = "app"
-	keyFlag    = "key"
-)
+	// TODO: store the proof or do something more interesting than just printing
+	fmt.Printf("Height: %d\n", height)
+	fmt.Println(string(res))
+	return nil
+
+}

--- a/commands/proofs/state.go
+++ b/commands/proofs/state.go
@@ -7,7 +7,8 @@ import (
 	"github.com/tendermint/tendermint/rpc/client"
 )
 
-var StatePresenters = proofs.NewPresenters()
+var StateGetPresenters = proofs.NewPresenters()
+var StateListPresenters = proofs.NewPresenters()
 
 var stateCmd = &cobra.Command{
 	Use:   "state",
@@ -20,13 +21,19 @@ data to other peers as needed.
 `,
 }
 
-var StateProverCommander = ProofCommander{
+var StateGetProverCommander = ProofCommander{
 	ProverFunc: stateProver,
-	Presenters: StatePresenters,
+	Presenters: StateGetPresenters,
+}
+
+var StateListProverCommander = ProofCommander{
+	ProverFunc: stateProver,
+	Presenters: StateListPresenters,
 }
 
 func init() {
-	StateProverCommander.RegisterGet(stateCmd)
+	StateGetProverCommander.RegisterGet(stateCmd)
+	StateListProverCommander.RegisterList(stateCmd)
 	RootCmd.AddCommand(stateCmd)
 }
 

--- a/commands/proofs/state.go
+++ b/commands/proofs/state.go
@@ -20,13 +20,13 @@ data to other peers as needed.
 `,
 }
 
-var stateProverCommander = ProofCommander{
+var StateProverCommander = ProofCommander{
 	ProverFunc: stateProver,
 	Presenters: StatePresenters,
 }
 
 func init() {
-	stateProverCommander.RegisterGet(stateCmd)
+	StateProverCommander.RegisterGet(stateCmd)
 	RootCmd.AddCommand(stateCmd)
 }
 
@@ -35,6 +35,6 @@ func stateProver(node client.Client) lc.Prover {
 }
 
 // RegisterProofStateSubcommand registers a subcommand to proof state cmd
-func RegisterProofStateSubcommand(cmdReg func(ProofCommander) *cobra.Command) {
-	stateProverCommander.Register(stateCmd, cmdReg)
+func RegisterProofStateSubcommand(cmdReg *cobra.Command) {
+	stateCmd.AddCommand(cmdReg)
 }

--- a/commands/proofs/state.go
+++ b/commands/proofs/state.go
@@ -32,3 +32,8 @@ func init() {
 func stateProver(node client.Client) lc.Prover {
 	return proofs.NewAppProver(node)
 }
+
+// RegisterProofStateSubcommand registers a subcommand to proof state cmd
+func RegisterProofStateSubcommand(cmd *cobra.Command) {
+	stateCmd.AddCommand(cmd)
+}

--- a/commands/proofs/state.go
+++ b/commands/proofs/state.go
@@ -2,46 +2,42 @@ package proofs
 
 import (
 	"github.com/spf13/cobra"
-	lc "github.com/tendermint/light-client"
+	"github.com/spf13/viper"
+	"github.com/tendermint/go-wire/data"
+	"github.com/tendermint/light-client/commands"
 	"github.com/tendermint/light-client/proofs"
-	"github.com/tendermint/tendermint/rpc/client"
 )
 
-var StateGetPresenters = proofs.NewPresenters()
-var StateListPresenters = proofs.NewPresenters()
-
 var stateCmd = &cobra.Command{
-	Use:   "state",
+	Use:   "key [key]",
 	Short: "Handle proofs for state of abci app",
-	Long: `Proofs allows you to validate abci state with merkle proofs.
+	Long: `This will look up a given key in the abci app, verify the proof,
+and output it as hex.
 
-These proofs tie the data to a checkpoint, which is managed by "seeds".
-Here we can validate these proofs and import/export them to prove specific
-data to other peers as needed.
-`,
+If you want json output, use an app-specific command that knows key and value structure.`,
+	RunE: doStateQuery,
 }
 
-var StateGetProverCommander = ProofCommander{
-	ProverFunc: stateProver,
-	Presenters: StateGetPresenters,
-}
+func doStateQuery(cmd *cobra.Command, args []string) error {
+	// parse cli
+	height := viper.GetInt(heightFlag)
+	bkey, err := ParseHexKey(args, nil)
+	if err != nil {
+		return err
+	}
 
-var StateListProverCommander = ProofCommander{
-	ProverFunc: stateProver,
-	Presenters: StateListPresenters,
-}
+	// get the proof -> this will be used by all prover commands
+	node := commands.GetNode()
+	prover := proofs.NewAppProver(node)
+	proof, err := GetProof(node, prover, bkey, height)
+	if err != nil {
+		return err
+	}
 
-func init() {
-	StateGetProverCommander.RegisterGet(stateCmd)
-	StateListProverCommander.RegisterList(stateCmd)
-	RootCmd.AddCommand(stateCmd)
-}
+	// state just returns raw hex....
+	info := data.Bytes(proof.Data())
 
-func stateProver(node client.Client) lc.Prover {
-	return proofs.NewAppProver(node)
-}
-
-// RegisterProofStateSubcommand registers a subcommand to proof state cmd
-func RegisterProofStateSubcommand(cmdReg *cobra.Command) {
-	stateCmd.AddCommand(cmdReg)
+	// we can reuse this output for other commands for text/json
+	// unless they do something special like store a file to disk
+	return OutputProof(info, proof.BlockHeight())
 }

--- a/commands/proofs/state.go
+++ b/commands/proofs/state.go
@@ -22,7 +22,7 @@ If you want json output, use an app-specific command that knows key and value st
 func doKeyQuery(cmd *cobra.Command, args []string) error {
 	// parse cli
 	height := GetHeight()
-	bkey, err := ParseHexKey(args, nil)
+	bkey, err := ParseHexKey(args, "key")
 	if err != nil {
 		return err
 	}

--- a/commands/proofs/state.go
+++ b/commands/proofs/state.go
@@ -2,25 +2,26 @@ package proofs
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
 	"github.com/tendermint/go-wire/data"
+
 	"github.com/tendermint/light-client/commands"
 	"github.com/tendermint/light-client/proofs"
 )
 
-var stateCmd = &cobra.Command{
+var keyCmd = &cobra.Command{
 	Use:   "key [key]",
 	Short: "Handle proofs for state of abci app",
 	Long: `This will look up a given key in the abci app, verify the proof,
 and output it as hex.
 
 If you want json output, use an app-specific command that knows key and value structure.`,
-	RunE: doStateQuery,
+	RunE: doKeyQuery,
 }
 
-func doStateQuery(cmd *cobra.Command, args []string) error {
+func doKeyQuery(cmd *cobra.Command, args []string) error {
 	// parse cli
-	height := viper.GetInt(heightFlag)
+	height := GetHeight()
 	bkey, err := ParseHexKey(args, nil)
 	if err != nil {
 		return err

--- a/commands/proofs/state.go
+++ b/commands/proofs/state.go
@@ -20,12 +20,13 @@ data to other peers as needed.
 `,
 }
 
+var stateProverCommander = ProofCommander{
+	ProverFunc: stateProver,
+	Presenters: StatePresenters,
+}
+
 func init() {
-	stateProver := ProofCommander{
-		ProverFunc: stateProver,
-		Presenters: StatePresenters,
-	}
-	stateProver.Register(stateCmd)
+	stateProverCommander.RegisterGet(stateCmd)
 	RootCmd.AddCommand(stateCmd)
 }
 
@@ -34,6 +35,6 @@ func stateProver(node client.Client) lc.Prover {
 }
 
 // RegisterProofStateSubcommand registers a subcommand to proof state cmd
-func RegisterProofStateSubcommand(cmd *cobra.Command) {
-	stateCmd.AddCommand(cmd)
+func RegisterProofStateSubcommand(cmdReg func(ProofCommander) *cobra.Command) {
+	stateProverCommander.Register(stateCmd, cmdReg)
 }

--- a/commands/proofs/tx.go
+++ b/commands/proofs/tx.go
@@ -24,7 +24,7 @@ data to other peers as needed.
 func doTxQuery(cmd *cobra.Command, args []string) error {
 	// parse cli
 	height := GetHeight()
-	bkey, err := ParseHexKey(args, nil)
+	bkey, err := ParseHexKey(args, "txhash")
 	if err != nil {
 		return err
 	}

--- a/commands/proofs/tx.go
+++ b/commands/proofs/tx.go
@@ -2,7 +2,7 @@ package proofs
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
 	"github.com/tendermint/light-client/commands"
 	"github.com/tendermint/light-client/proofs"
 )
@@ -23,7 +23,7 @@ data to other peers as needed.
 
 func doTxQuery(cmd *cobra.Command, args []string) error {
 	// parse cli
-	height := viper.GetInt(heightFlag)
+	height := GetHeight()
 	bkey, err := ParseHexKey(args, nil)
 	if err != nil {
 		return err

--- a/commands/proofs/tx.go
+++ b/commands/proofs/tx.go
@@ -25,7 +25,7 @@ func init() {
 		ProverFunc: txProver,
 		Presenters: TxPresenters,
 	}
-	txProver.Register(txCmd)
+	txProver.RegisterGet(txCmd)
 	RootCmd.AddCommand(txCmd)
 }
 

--- a/commands/proofs/tx.go
+++ b/commands/proofs/tx.go
@@ -2,15 +2,15 @@ package proofs
 
 import (
 	"github.com/spf13/cobra"
-	lc "github.com/tendermint/light-client"
+	"github.com/spf13/viper"
+	"github.com/tendermint/light-client/commands"
 	"github.com/tendermint/light-client/proofs"
-	"github.com/tendermint/tendermint/rpc/client"
 )
 
 var TxPresenters = proofs.NewPresenters()
 
 var txCmd = &cobra.Command{
-	Use:   "tx",
+	Use:   "tx [txhash]",
 	Short: "Handle proofs of commited txs",
 	Long: `Proofs allows you to validate abci state with merkle proofs.
 
@@ -18,17 +18,32 @@ These proofs tie the data to a checkpoint, which is managed by "seeds".
 Here we can validate these proofs and import/export them to prove specific
 data to other peers as needed.
 `,
+	RunE: doTxQuery,
 }
 
-func init() {
-	txProver := ProofCommander{
-		ProverFunc: txProver,
-		Presenters: TxPresenters,
+func doTxQuery(cmd *cobra.Command, args []string) error {
+	// parse cli
+	height := viper.GetInt(heightFlag)
+	bkey, err := ParseHexKey(args, nil)
+	if err != nil {
+		return err
 	}
-	txProver.RegisterGet(txCmd)
-	RootCmd.AddCommand(txCmd)
-}
 
-func txProver(node client.Client) lc.Prover {
-	return proofs.NewTxProver(node)
+	// get the proof -> this will be used by all prover commands
+	node := commands.GetNode()
+	prover := proofs.NewTxProver(node)
+	proof, err := GetProof(node, prover, bkey, height)
+	if err != nil {
+		return err
+	}
+
+	// auto-determine which tx it was, over all registered tx types
+	info, err := TxPresenters.BruteForce(proof.Data())
+	if err != nil {
+		return err
+	}
+
+	// we can reuse this output for other commands for text/json
+	// unless they do something special like store a file to disk
+	return OutputProof(info, proof.BlockHeight())
 }

--- a/proofs/presenters.go
+++ b/proofs/presenters.go
@@ -81,3 +81,7 @@ func (k KeyMaker) MakeKey(str string) ([]byte, error) {
 	}
 	return r, errors.WithStack(err)
 }
+
+func ParseHexKey(str string) ([]byte, error) {
+	return KeyMaker{}.MakeKey(str)
+}

--- a/proofs/presenters.go
+++ b/proofs/presenters.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 
 	"github.com/pkg/errors"
+
 	data "github.com/tendermint/go-wire/data"
 )
 


### PR DESCRIPTION
This is equivalent to RegisterQuerySubcommand within the heavy client, allows a space to have custom plugin proofs for custom flags and more complex responses. 

Closes #13 