### PR TITLE
Add cli for tendermint rpc

### DIFF
--- a/cmd/tmcli/main.go
+++ b/cmd/tmcli/main.go
@@ -68,6 +68,7 @@ import (
 	"github.com/tendermint/light-client/commands"
 	"github.com/tendermint/light-client/commands/proofs"
 	"github.com/tendermint/light-client/commands/proxy"
+	rpccmd "github.com/tendermint/light-client/commands/rpc"
 	"github.com/tendermint/light-client/commands/seeds"
 	"github.com/tendermint/light-client/commands/txs"
 	"github.com/tendermint/tmlibs/cli"
@@ -109,6 +110,7 @@ func init() {
 		commands.ResetCmd,
 		keycmd.RootCmd,
 		seeds.RootCmd,
+		rpccmd.RootCmd,
 		pr,
 		tr,
 		proxy.RootCmd)

--- a/commands/rpc/helpers.go
+++ b/commands/rpc/helpers.go
@@ -1,0 +1,49 @@
+package rpc
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/tendermint/light-client/commands"
+
+	"github.com/tendermint/tendermint/rpc/client"
+)
+
+var waitCmd = &cobra.Command{
+	Use:   "wait",
+	Short: "Wait until a given height, or number of new blocks",
+	RunE:  commands.RequireInit(runWait),
+}
+
+func init() {
+	waitCmd.Flags().Int(FlagHeight, -1, "wait for block height")
+	waitCmd.Flags().Int(FlagDelta, -1, "wait for given number of nodes")
+}
+
+func runWait(cmd *cobra.Command, args []string) error {
+	c := commands.GetNode()
+	h := viper.GetInt(FlagHeight)
+	if h == -1 {
+		// read from delta
+		d := viper.GetInt(FlagDelta)
+		if d == -1 {
+			return errors.New("Must set --height or --delta")
+		}
+		status, err := c.Status()
+		if err != nil {
+			return err
+		}
+		h = status.LatestBlockHeight + d
+	}
+
+	// now wait
+	err := client.WaitForHeight(c, h, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Chain now at height %d\n", h)
+	return nil
+}

--- a/commands/rpc/insecure.go
+++ b/commands/rpc/insecure.go
@@ -1,0 +1,51 @@
+package rpc
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/tendermint/light-client/commands"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Query the status of the node",
+	RunE:  commands.RequireInit(runStatus),
+}
+
+func runStatus(cmd *cobra.Command, args []string) error {
+	c := commands.GetNode()
+	status, err := c.Status()
+	if err != nil {
+		return err
+	}
+	return printResult(status)
+}
+
+var genesisCmd = &cobra.Command{
+	Use:   "genesis",
+	Short: "Query the genesis of the node",
+	RunE:  commands.RequireInit(runGenesis),
+}
+
+func runGenesis(cmd *cobra.Command, args []string) error {
+	c := commands.GetNode()
+	genesis, err := c.Genesis()
+	if err != nil {
+		return err
+	}
+	return printResult(genesis)
+}
+
+var validatorsCmd = &cobra.Command{
+	Use:   "validators",
+	Short: "Query the validators of the node",
+	RunE:  commands.RequireInit(runValidators),
+}
+
+func runValidators(cmd *cobra.Command, args []string) error {
+	c := commands.GetNode()
+	validators, err := c.Validators()
+	if err != nil {
+		return err
+	}
+	return printResult(validators)
+}

--- a/commands/rpc/insecure.go
+++ b/commands/rpc/insecure.go
@@ -20,6 +20,21 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	return printResult(status)
 }
 
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Query info on the abci app",
+	RunE:  commands.RequireInit(runInfo),
+}
+
+func runInfo(cmd *cobra.Command, args []string) error {
+	c := commands.GetNode()
+	info, err := c.ABCIInfo()
+	if err != nil {
+		return err
+	}
+	return printResult(info)
+}
+
 var genesisCmd = &cobra.Command{
 	Use:   "genesis",
 	Short: "Query the genesis of the node",

--- a/commands/rpc/root.go
+++ b/commands/rpc/root.go
@@ -12,12 +12,20 @@ import (
 	"github.com/tendermint/light-client/commands"
 )
 
+const (
+	FlagDelta  = "delta"
+	FlagHeight = "height"
+	FlagMax    = "max"
+	FlagMin    = "min"
+)
+
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "rpc",
 	Short: "Query the tendermint rpc, validating everything with a proof",
 }
 
+// TODO: add support for subscribing to events????
 func init() {
 	RootCmd.AddCommand(
 		statusCmd,
@@ -27,6 +35,7 @@ func init() {
 		blockCmd,
 		commitCmd,
 		headersCmd,
+		waitCmd,
 	)
 }
 
@@ -54,20 +63,3 @@ func printResult(res interface{}) error {
 	fmt.Println(string(json))
 	return nil
 }
-
-// // First step, proxy with no checks....
-// func routes(c client.Client) map[string]*rpc.RPCFunc {
-
-// 	return map[string]*rpc.RPCFunc{
-// 		// Subscribe/unsubscribe are reserved for websocket events.
-// 		// We can just use the core tendermint impl, which uses the
-// 		// EventSwitch we registered in NewWebsocketManager above
-// 		"subscribe":   rpc.NewWSRPCFunc(core.Subscribe, "event"),
-// 		"unsubscribe": rpc.NewWSRPCFunc(core.Unsubscribe, "event"),
-
-// 		// info API
-// 		"blockchain": rpc.NewRPCFunc(c.BlockchainInfo, "minHeight,maxHeight"),
-// 		"block":      rpc.NewRPCFunc(c.Block, "height"),
-// 		"commit":     rpc.NewRPCFunc(c.Commit, "height"),
-// 	}
-// }

--- a/commands/rpc/root.go
+++ b/commands/rpc/root.go
@@ -25,6 +25,8 @@ func init() {
 		genesisCmd,
 		validatorsCmd,
 		blockCmd,
+		commitCmd,
+		headersCmd,
 	)
 }
 

--- a/commands/rpc/root.go
+++ b/commands/rpc/root.go
@@ -21,8 +21,10 @@ var RootCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(
 		statusCmd,
+		infoCmd,
 		genesisCmd,
 		validatorsCmd,
+		blockCmd,
 	)
 }
 
@@ -62,21 +64,8 @@ func printResult(res interface{}) error {
 // 		"unsubscribe": rpc.NewWSRPCFunc(core.Unsubscribe, "event"),
 
 // 		// info API
-// 		"status":     rpc.NewRPCFunc(c.Status, ""),
 // 		"blockchain": rpc.NewRPCFunc(c.BlockchainInfo, "minHeight,maxHeight"),
-// 		"genesis":    rpc.NewRPCFunc(c.Genesis, ""),
 // 		"block":      rpc.NewRPCFunc(c.Block, "height"),
 // 		"commit":     rpc.NewRPCFunc(c.Commit, "height"),
-// 		"tx":         rpc.NewRPCFunc(c.Tx, "hash,prove"),
-// 		"validators": rpc.NewRPCFunc(c.Validators, ""),
-
-// 		// broadcast API
-// 		"broadcast_tx_commit": rpc.NewRPCFunc(c.BroadcastTxCommit, "tx"),
-// 		"broadcast_tx_sync":   rpc.NewRPCFunc(c.BroadcastTxSync, "tx"),
-// 		"broadcast_tx_async":  rpc.NewRPCFunc(c.BroadcastTxAsync, "tx"),
-
-// 		// abci API
-// 		"abci_query": rpc.NewRPCFunc(c.ABCIQuery, "path,data,prove"),
-// 		"abci_info":  rpc.NewRPCFunc(c.ABCIInfo, ""),
 // 	}
 // }

--- a/commands/rpc/root.go
+++ b/commands/rpc/root.go
@@ -1,0 +1,82 @@
+package rpc
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tendermint/go-wire/data"
+	"github.com/tendermint/tendermint/rpc/client"
+
+	certclient "github.com/tendermint/light-client/certifiers/client"
+	"github.com/tendermint/light-client/commands"
+)
+
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "rpc",
+	Short: "Query the tendermint rpc, validating everything with a proof",
+}
+
+func init() {
+	RootCmd.AddCommand(
+		statusCmd,
+		genesisCmd,
+		validatorsCmd,
+	)
+}
+
+func getSecureNode() (client.Client, error) {
+	// First, connect a client
+	c := commands.GetNode()
+	cert, err := commands.GetCertifier()
+	if err != nil {
+		return nil, err
+	}
+	sc := certclient.Wrap(c, cert)
+	return sc, nil
+}
+
+// printResult just writes the struct to the console, returns an error if it can't
+func printResult(res interface{}) error {
+	// TODO: handle text mode
+	// switch viper.Get(cli.OutputFlag) {
+	// case "text":
+	// case "json":
+	json, err := data.ToJSON(res)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(json))
+	return nil
+}
+
+// // First step, proxy with no checks....
+// func routes(c client.Client) map[string]*rpc.RPCFunc {
+
+// 	return map[string]*rpc.RPCFunc{
+// 		// Subscribe/unsubscribe are reserved for websocket events.
+// 		// We can just use the core tendermint impl, which uses the
+// 		// EventSwitch we registered in NewWebsocketManager above
+// 		"subscribe":   rpc.NewWSRPCFunc(core.Subscribe, "event"),
+// 		"unsubscribe": rpc.NewWSRPCFunc(core.Unsubscribe, "event"),
+
+// 		// info API
+// 		"status":     rpc.NewRPCFunc(c.Status, ""),
+// 		"blockchain": rpc.NewRPCFunc(c.BlockchainInfo, "minHeight,maxHeight"),
+// 		"genesis":    rpc.NewRPCFunc(c.Genesis, ""),
+// 		"block":      rpc.NewRPCFunc(c.Block, "height"),
+// 		"commit":     rpc.NewRPCFunc(c.Commit, "height"),
+// 		"tx":         rpc.NewRPCFunc(c.Tx, "hash,prove"),
+// 		"validators": rpc.NewRPCFunc(c.Validators, ""),
+
+// 		// broadcast API
+// 		"broadcast_tx_commit": rpc.NewRPCFunc(c.BroadcastTxCommit, "tx"),
+// 		"broadcast_tx_sync":   rpc.NewRPCFunc(c.BroadcastTxSync, "tx"),
+// 		"broadcast_tx_async":  rpc.NewRPCFunc(c.BroadcastTxAsync, "tx"),
+
+// 		// abci API
+// 		"abci_query": rpc.NewRPCFunc(c.ABCIQuery, "path,data,prove"),
+// 		"abci_info":  rpc.NewRPCFunc(c.ABCIInfo, ""),
+// 	}
+// }

--- a/commands/rpc/secure.go
+++ b/commands/rpc/secure.go
@@ -12,14 +12,17 @@ const (
 	FlagMin    = "min"
 )
 
-var blockCmd = &cobra.Command{
-	Use:   "block",
-	Short: "Get a validated block at the given height",
-	RunE:  commands.RequireInit(runBlock),
+func init() {
+	blockCmd.Flags().Int(FlagHeight, -1, "block height")
+	commitCmd.Flags().Int(FlagHeight, -1, "block height")
+	headersCmd.Flags().Int(FlagMin, -1, "minimum block height")
+	headersCmd.Flags().Int(FlagMax, -1, "maximum block height")
 }
 
-func init() {
-	blockCmd.Flags().Int(FlagHeight, 0, "block height")
+var blockCmd = &cobra.Command{
+	Use:   "block",
+	Short: "Get a validated block at a given height",
+	RunE:  commands.RequireInit(runBlock),
 }
 
 func runBlock(cmd *cobra.Command, args []string) error {
@@ -30,4 +33,37 @@ func runBlock(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	return printResult(block)
+}
+
+var commitCmd = &cobra.Command{
+	Use:   "commit",
+	Short: "Get the header and commit signature at a given height",
+	RunE:  commands.RequireInit(runCommit),
+}
+
+func runCommit(cmd *cobra.Command, args []string) error {
+	c := commands.GetNode()
+	h := viper.GetInt(FlagHeight)
+	commit, err := c.Commit(h)
+	if err != nil {
+		return err
+	}
+	return printResult(commit)
+}
+
+var headersCmd = &cobra.Command{
+	Use:   "headers",
+	Short: "Get all headers in the given height range",
+	RunE:  commands.RequireInit(runHeaders),
+}
+
+func runHeaders(cmd *cobra.Command, args []string) error {
+	c := commands.GetNode()
+	min := viper.GetInt(FlagMin)
+	max := viper.GetInt(FlagMax)
+	headers, err := c.BlockchainInfo(min, max)
+	if err != nil {
+		return err
+	}
+	return printResult(headers)
 }

--- a/commands/rpc/secure.go
+++ b/commands/rpc/secure.go
@@ -1,0 +1,33 @@
+package rpc
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/tendermint/light-client/commands"
+)
+
+const (
+	FlagHeight = "height"
+	FlagMax    = "max"
+	FlagMin    = "min"
+)
+
+var blockCmd = &cobra.Command{
+	Use:   "block",
+	Short: "Get a validated block at the given height",
+	RunE:  commands.RequireInit(runBlock),
+}
+
+func init() {
+	blockCmd.Flags().Int(FlagHeight, 0, "block height")
+}
+
+func runBlock(cmd *cobra.Command, args []string) error {
+	c := commands.GetNode()
+	h := viper.GetInt(FlagHeight)
+	block, err := c.Block(h)
+	if err != nil {
+		return err
+	}
+	return printResult(block)
+}

--- a/commands/rpc/secure.go
+++ b/commands/rpc/secure.go
@@ -6,12 +6,6 @@ import (
 	"github.com/tendermint/light-client/commands"
 )
 
-const (
-	FlagHeight = "height"
-	FlagMax    = "max"
-	FlagMin    = "min"
-)
-
 func init() {
 	blockCmd.Flags().Int(FlagHeight, -1, "block height")
 	commitCmd.Flags().Int(FlagHeight, -1, "block height")
@@ -26,7 +20,11 @@ var blockCmd = &cobra.Command{
 }
 
 func runBlock(cmd *cobra.Command, args []string) error {
-	c := commands.GetNode()
+	c, err := getSecureNode()
+	if err != nil {
+		return err
+	}
+
 	h := viper.GetInt(FlagHeight)
 	block, err := c.Block(h)
 	if err != nil {
@@ -42,7 +40,11 @@ var commitCmd = &cobra.Command{
 }
 
 func runCommit(cmd *cobra.Command, args []string) error {
-	c := commands.GetNode()
+	c, err := getSecureNode()
+	if err != nil {
+		return err
+	}
+
 	h := viper.GetInt(FlagHeight)
 	commit, err := c.Commit(h)
 	if err != nil {
@@ -58,7 +60,11 @@ var headersCmd = &cobra.Command{
 }
 
 func runHeaders(cmd *cobra.Command, args []string) error {
-	c := commands.GetNode()
+	c, err := getSecureNode()
+	if err != nil {
+		return err
+	}
+
 	min := viper.GetInt(FlagMin)
 	max := viper.GetInt(FlagMax)
 	headers, err := c.BlockchainInfo(min, max)

--- a/test/rpc.sh
+++ b/test/rpc.sh
@@ -58,6 +58,11 @@ test01getInsecure() {
   assertTrue "sensible heights: $SHEIGHT / $VHEIGHT" "test $VHEIGHT -ge $SHEIGHT"
   VCNT=$(echo ${VALS} | jq '.validators | length')
   assertEquals "one validator" "1" "$VCNT"
+
+  INFO=$(tmcli rpc info)
+  assertTrue "get info" "$?"
+  DATA=$(echo $INFO | jq .response.data)
+  assertEquals "dummy info" '"{\"size\":0}"' "$DATA"
 }
 
 # load and run these tests with shunit2!

--- a/test/rpc.sh
+++ b/test/rpc.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+oneTimeSetUp() {
+  BASE=~/.lc_init_test
+  rm -rf "$BASE"
+  mkdir -p "$BASE"
+
+  SERVER="${BASE}/server"
+  SERVER_LOG="${BASE}/tendermint.log"
+
+  tendermint init --home="$SERVER" >> "$SERVER_LOG"
+  if ! assertTrue $?; then return 1; fi
+
+  GENESIS_FILE=${SERVER}/genesis.json
+  CHAIN_ID=$(cat ${GENESIS_FILE} | jq .chain_id | tr -d \")
+
+  printf "starting tendermint...\n"
+  tendermint node --proxy_app=dummy --home="$SERVER" >> "$SERVER_LOG" 2>&1 &
+  sleep 5
+  PID_SERVER=$!
+  disown
+  if ! ps $PID_SERVER >/dev/null; then
+    echo "**STARTUP FAILED**"
+    cat $SERVER_LOG
+    return 1
+  fi
+
+  # this sets the base for all client queries in the tests
+  export TMHOME=${BASE}/client
+  tmcli init --node=tcp://localhost:46657 --genesis=${GENESIS_FILE} > /dev/null 2>&1
+  if ! assertTrue "initialized light-client" "$?"; then
+    return 1
+  fi
+}
+
+oneTimeTearDown() {
+  printf "\nstopping tendermint..."
+  kill -9 $PID_SERVER >/dev/null 2>&1
+  sleep 1
+}
+
+test01getInsecure() {
+  GENESIS=$(tmcli rpc genesis)
+  assertTrue "get genesis" "$?"
+  MYCHAIN=$(echo ${GENESIS} | jq .genesis.chain_id | tr -d \")
+  assertEquals "genesis chain matches" "${CHAIN_ID}" "${MYCHAIN}"
+
+  STATUS=$(tmcli rpc status)
+  assertTrue "get status" "$?"
+  SHEIGHT=$(echo ${STATUS} | jq .latest_block_height)
+  assertTrue "parsed status" "$?"
+  assertNotNull "has a height" "${SHEIGHT}"
+
+  VALS=$(tmcli rpc validators)
+  assertTrue "get validators" "$?"
+  VHEIGHT=$(echo ${VALS} | jq .block_height)
+  assertTrue "parsed validators" "$?"
+  assertTrue "sensible heights: $SHEIGHT / $VHEIGHT" "test $VHEIGHT -ge $SHEIGHT"
+  VCNT=$(echo ${VALS} | jq '.validators | length')
+  assertEquals "one validator" "1" "$VCNT"
+}
+
+# load and run these tests with shunit2!
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" #get this files directory
+. $DIR/shunit2

--- a/test/rpc.sh
+++ b/test/rpc.sh
@@ -101,7 +101,24 @@ test02getSecure() {
   # most recent first, so the commit header is second....
   HHEAD=$(echo $HEADERS | jq .block_metas[1].header)
   assertEquals "commit and header" "$CHEAD" "$HHEAD"
+}
 
+test03waiting() {
+  START=$(tmcli rpc status | jq .latest_block_height)
+  assertTrue "get status" "$?"
+
+  let "NEXT = $START + 5"
+  assertFalse "no args" "tmcli rpc wait"
+  assertFalse "too long" "tmcli rpc wait --height=1234"
+  assertTrue "normal wait" "tmcli rpc wait --height=$NEXT"
+
+  STEP=$(tmcli rpc status | jq .latest_block_height)
+  assertEquals "wait until height" "$NEXT" "$STEP"
+
+  let "NEXT = $STEP + 3"
+  assertTrue "tmcli rpc wait --delta=3"
+  STEP=$(tmcli rpc status | jq .latest_block_height)
+  assertEquals "wait for delta" "$NEXT" "$STEP"
 }
 
 # load and run these tests with shunit2!


### PR DESCRIPTION
Resolve issue #32 

Adds a number of new commands under `tmcli rpc`:

* status
* info (abci_info)
* genesis
* validators
* block
* commit
* headers
* wait (for a height, for scripts)

block, commit, headers validate the info as they have proofs