### PR TITLE
Add Certifier interface

### DIFF
--- a/certifiers/certifier.go
+++ b/certifiers/certifier.go
@@ -1,0 +1,10 @@
+package certifiers
+
+import (
+	lc "github.com/tendermint/light-client"
+)
+
+// Certifier is the interface all certifiers implement.
+type Certifier interface {
+	Certify(check lc.Checkpoint) error
+}


### PR DESCRIPTION
This is useful if one doesn't want to depend on a specific certifier. It also provides more type-safety.